### PR TITLE
fix: Top value of `text action bar` content rect

### DIFF
--- a/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
@@ -246,4 +246,8 @@ public final class TerminalRenderer {
     public int getFontLineSpacing() {
         return mFontLineSpacing;
     }
+
+    public int getFontLineSpacingAndAscent() {
+        return mFontLineSpacingAndAscent;
+    }
 }

--- a/terminal-view/src/main/java/com/termux/view/textselection/TextSelectionCursorController.java
+++ b/terminal-view/src/main/java/com/termux/view/textselection/TextSelectionCursorController.java
@@ -185,7 +185,7 @@ public class TextSelectionCursorController implements CursorController {
             public void onGetContentRect(ActionMode mode, View view, Rect outRect) {
                 int x1 = Math.round(mSelX1 * terminalView.mRenderer.getFontWidth());
                 int x2 = Math.round(mSelX2 * terminalView.mRenderer.getFontWidth());
-                int y1 = Math.round((mSelY1 - 1 - terminalView.getTopRow()) * terminalView.mRenderer.getFontLineSpacing());
+                int y1 = Math.round((mSelY1 - terminalView.getTopRow()) * terminalView.mRenderer.getFontLineSpacing());
                 int y2 = Math.round((mSelY2 + 1 - terminalView.getTopRow()) * terminalView.mRenderer.getFontLineSpacing());
 
                 if (x1 > x2) {
@@ -195,7 +195,7 @@ public class TextSelectionCursorController implements CursorController {
                 }
 
                 int terminalBottom = terminalView.getBottom();
-                int top = y1 + mHandleHeight;
+                int top = y1 + terminalView.mRenderer.getFontLineSpacingAndAscent();
                 int bottom = y2 + mHandleHeight;
                 if (top > terminalBottom) top = terminalBottom;
                 if (bottom > terminalBottom) bottom = terminalBottom;


### PR DESCRIPTION
Handle is draw from text's baseline, will keep content's bottom = baseline + handle.height, but content's top should = baseline + font's ascent.
## Before
#### Small font
![IMG_20220527_215803](https://user-images.githubusercontent.com/32380878/170714873-c8e78773-bf26-4706-8ce1-d78198117fc4.jpg)
#### Large font:
![IMG_20220527_215832](https://user-images.githubusercontent.com/32380878/170714884-43b0fc17-4991-4481-ad2b-f8db7e0edf8a.jpg)
## After
#### Small font size
![IMG_20220527_215934](https://user-images.githubusercontent.com/32380878/170714887-72013654-ef28-47cd-8e99-59c9c4dbf757.jpg)
#### Large font size
![IMG_20220527_220017](https://user-images.githubusercontent.com/32380878/170714889-c891e9ee-db39-4f01-9f24-9df701786a17.jpg)
